### PR TITLE
Explicit relation to MainClass

### DIFF
--- a/snippets/core/classes/CustomLogger.js
+++ b/snippets/core/classes/CustomLogger.js
@@ -1,6 +1,6 @@
 Aria.classDefinition({
 	$classpath : "snippets.core.classes.CustomLogger",
-	$dependencies : ["ariadoc.snippets.core.classes.MainClass"],
+	$dependencies : ["snippets.core.classes.MainClass"],
 	$singleton : true,
 	
 	$statics : {


### PR DESCRIPTION
MainClass is a dependency on which CustomLogger listens to events. Storage of the current log level is also more explicit with a variable explicitly stored.
