### PR TITLE
DomElementWrapper.get|setClassName were removed in 1.3.0

### DIFF
--- a/samples/templates/cssTemplates/MainTemplateScript.js
+++ b/samples/templates/cssTemplates/MainTemplateScript.js
@@ -9,11 +9,11 @@ Aria.tplScriptDefinition({
 		 */
 		changeClass : function (evt, args) {
 			var el = this.$getElementById(args.id);
-			var cssClass = el.getClassName();
+			var cssClass = el.classList.getClassName();
 			if (cssClass == "shoppingItemTaken") {
-				el.setClassName("shoppingItem");
+				el.classList.setClassName("shoppingItem");
 			} else {
-				el.setClassName("shoppingItemTaken");
+				el.classList.setClassName("shoppingItemTaken");
 			}
 		}
 	}

--- a/samples/widgets/autocomplete/onchange/OnChangeScript.js
+++ b/samples/widgets/autocomplete/onchange/OnChangeScript.js
@@ -18,7 +18,7 @@ Aria.tplScriptDefinition({
 		 * Animation is done is CSS so it only works in modern browsers.
 		 */
 		onChange : function () {
-			this.$getElementById("notify").setClassName("flash changeAlert");
+			this.$getElementById("notify").classList.setClassName("flash changeAlert");
 
 			aria.core.Timer.addCallback({
 				fn : this._animationEnd,
@@ -31,7 +31,7 @@ Aria.tplScriptDefinition({
 		 * Hide the notification.
 		 */
 		_animationEnd : function () {
-			this.$getElementById("notify").setClassName("hidden changeAlert");
+			this.$getElementById("notify").classList.setClassName("hidden changeAlert");
 		}
 	}
 });

--- a/samples/widgets/datepicker/customized/CustomizedCalendarScript.js
+++ b/samples/widgets/datepicker/customized/CustomizedCalendarScript.js
@@ -62,14 +62,14 @@ Aria.tplScriptDefinition({
 		mouseOverDay : function (evt) {
 			var date = evt.target.getExpando("date");
 			if (date) {
-				evt.target.setClassName(evt.target.getClassName().replace(this.skin.baseCSS+"mouseOut", this.skin.baseCSS+"mouseOver"));
+				evt.target.classList.setClassName(evt.target.classList.getClassName().replace(this.skin.baseCSS+"mouseOut", this.skin.baseCSS+"mouseOver"));
 			}
 		},
 
 		mouseOutDay : function (evt) {
 			var date = evt.target.getExpando("date");
 			if (date) {
-				evt.target.setClassName(evt.target.getClassName().replace(this.skin.baseCSS+"mouseOver", this.skin.baseCSS+"mouseOut"));
+				evt.target.classList.setClassName(evt.target.classList.getClassName().replace(this.skin.baseCSS+"mouseOver", this.skin.baseCSS+"mouseOut"));
 			}
 		}
 	}

--- a/snippets/templates/domInteractions/DomInteractionTemplateScript.js
+++ b/snippets/templates/domInteractions/DomInteractionTemplateScript.js
@@ -8,7 +8,7 @@ Aria.tplScriptDefinition({
 		myPublicFunction : function () {
 			////#domInteractions
 			var myDiv = this.$getElementById("myDivId");
-			myDiv.setClassName("newClass");
+			myDiv.classList.setClassName("newClass");
 
 			var mySection = this.$getElementById("mySectionDiv");
 			mySection.insertAdjacentSection("beforeBegin", newSectionCfg);


### PR DESCRIPTION
See https://github.com/ariatemplates/ariatemplates/commit/d49734f4d83ea239ca9c5b19f0a2db8dba3d39ff

Close #10
