### PR TITLE
Updating the bookmarklet to open debug tools directly

### DIFF
--- a/snippets/utils/Logging.js
+++ b/snippets/utils/Logging.js
@@ -31,7 +31,7 @@ Aria.classDefinition({
 
 
     ////#enableDebugTools
-    javascript:aria.core.AppEnvironment.updateEnvironment({contextualMenu:{enabled:true}});
+    javascript:Aria.load({classes:['aria.tools.ToolsBridge'],oncomplete:function(){aria.tools.ToolsBridge.open()}});
     ////#enableDebugTools
     */
   }


### PR DESCRIPTION
The previous bookmarklet does not directly open the debug tools as expected in the [documentation](http://ariatemplates.com/usermanual/latest/logging_and_debugging#debug-tools)
