### PR TITLE
use `macro` instead of `contentMacro`

### DIFF
--- a/samples/templates/keyboardnavigation/applicationLevelKeyMap/KeyMap.tpl
+++ b/samples/templates/keyboardnavigation/applicationLevelKeyMap/KeyMap.tpl
@@ -14,7 +14,7 @@
         {@aria:Dialog {
             title: "KeyMap",
             modal: true,
-            contentMacro : "dialogContent",
+            macro : "dialogContent",
             bind:{
                 "visible": { inside: data, to: 'dialogVisible' }
             }

--- a/samples/templates/keyboardnavigation/bubbleKeyMap/KeyMap.tpl
+++ b/samples/templates/keyboardnavigation/bubbleKeyMap/KeyMap.tpl
@@ -13,7 +13,7 @@
         {@aria:Dialog {
             title: "KeyMap",
             modal: true,
-            contentMacro : "dialogContent",
+            macro : "dialogContent",
             bind:{
                 "visible": { inside: data, to: 'dialogVisible' }
             }

--- a/samples/templates/keyboardnavigation/sectionkeyMap/KeyMap.tpl
+++ b/samples/templates/keyboardnavigation/sectionkeyMap/KeyMap.tpl
@@ -12,7 +12,7 @@
         {@aria:Dialog {
             title: "KeyMap",
             modal: true,
-            contentMacro : "dialogContent",
+            macro : "dialogContent",
             bind:{
                 "visible": { inside: data, to: 'dialogVisible' }
             }

--- a/samples/templates/keyboardnavigation/wildcardKeyMap/KeyMap.tpl
+++ b/samples/templates/keyboardnavigation/wildcardKeyMap/KeyMap.tpl
@@ -14,7 +14,7 @@
         {@aria:Dialog {
             title: "KeyMap",
             modal: true,
-            contentMacro : "dialogContent",
+            macro : "dialogContent",
             bind:{
                 "visible": { inside: data, to: 'dialogVisible' }
             }

--- a/samples/utils/fileupload/FileUpload.tpl
+++ b/samples/utils/fileupload/FileUpload.tpl
@@ -29,7 +29,7 @@
      maxHeight: 500,
      bind:{
          "visible": { inside: data, to: 'dialogOpen' },
-         "contentMacro": { inside: data, to: 'contentMacro' }
+         "macro": { inside: data, to: 'macro' }
      }
   }/}
 

--- a/samples/utils/fileupload/FileUploadScript.js
+++ b/samples/utils/fileupload/FileUploadScript.js
@@ -37,7 +37,7 @@ Aria.tplScriptDefinition({
 			this.$refresh({
 				outputSection : "form"
 			});
-			this.$json.setValue(this.data, "contentMacro", "defaultContent");
+			this.$json.setValue(this.data, "macro", "defaultContent");
 			var responseToDisplay;
 			var responseXML = response.responseXML;
 			var docElement = responseXML.documentElement;
@@ -60,7 +60,7 @@ Aria.tplScriptDefinition({
 			this.$refresh({
 				outputSection : "form"
 			});
-			this.$json.setValue(this.data, "contentMacro", "errorContent");
+			this.$json.setValue(this.data, "macro", "errorContent");
 			this.$json.setValue(this.data, "dialogOpen", true);
 		},
 

--- a/samples/widgets/dialog/TemplateDialog.tpl
+++ b/samples/widgets/dialog/TemplateDialog.tpl
@@ -12,7 +12,7 @@
       maxHeight : 500,
       modal : true,
       visible : false,
-      contentMacro : "myContent",
+      macro : "myContent",
       bind : {
         "visible" : { inside : data,
           to : 'dialogOpen' }

--- a/samples/widgets/dialog/action/DialogActionSample.tpl
+++ b/samples/widgets/dialog/action/DialogActionSample.tpl
@@ -13,7 +13,7 @@
       width : 400,
       maxHeight : 500,
       visible : false,
-      contentMacro : "myContent",
+      macro : "myContent",
       onOpen : dialogOpen,
       onCloseClick : closeClick,
       bind : {

--- a/samples/widgets/dialog/binding/DialogBindingSample.tpl
+++ b/samples/widgets/dialog/binding/DialogBindingSample.tpl
@@ -28,8 +28,8 @@
       bind : {
         "visible" : { inside : data,
           to : 'dialogOpen' },
-        "contentMacro" : { inside : data,
-          to : 'contentMacro' },
+        "macro" : { inside : data,
+          to : 'macro' },
         "title" : { inside : data,
           to : 'dialogTitle' }
       },

--- a/samples/widgets/dialog/binding/DialogBindingSampleScript.js
+++ b/samples/widgets/dialog/binding/DialogBindingSampleScript.js
@@ -16,7 +16,7 @@ Aria.tplScriptDefinition({
 			this.$refresh(args);
 		},
 		loadContentBound: function (evt, args){
-			this.$json.setValue(this.data,"contentMacro",args);
+			this.$json.setValue(this.data,"macro",args);
 		},
 		addLine:function(){
 			if (this.data.dynamicLines == null) {
@@ -31,10 +31,10 @@ Aria.tplScriptDefinition({
 		},
 		dialogOpen:function(){
 
-			if (this.data["contentMacro"] && this.data["contentMacro"] != "defaultContent") {
+			if (this.data["macro"] && this.data["macro"] != "defaultContent") {
 				this.$focus("toFocus");
 			}else {
-				this.$json.setValue(this.data,"contentMacro","defaultContent");
+				this.$json.setValue(this.data,"macro","defaultContent");
 			}
 		},
 		closeClick: function(){

--- a/samples/widgets/dialog/movable/TemplateMovableDialog.tpl
+++ b/samples/widgets/dialog/movable/TemplateMovableDialog.tpl
@@ -34,7 +34,7 @@
         {var dataModel = data["view:Dialog"] /}
         {@aria:Dialog {
             id : "movableDialog",
-            contentMacro : {
+            macro : {
                 name : "displayDialogContent"
             },
             movable : true,

--- a/samples/widgets/dialog/resizable/TemplateResizableDialog.tpl
+++ b/samples/widgets/dialog/resizable/TemplateResizableDialog.tpl
@@ -34,7 +34,7 @@
         {var dataModel = data["view:Dialog"] /}
         {@aria:Dialog {
             id : "movableDialog",
-            contentMacro : {
+            macro : {
                 name : "displayDialogContent"
             },
             resizable : true,
@@ -92,7 +92,7 @@
         
       {section {
             id : "resizeText",
-            macro : "resizeContentMacro",
+            macro : "resizemacro",
             bindRefreshTo : [{
                 to : "resizetext",
                 inside : data["view:Dialog"],
@@ -115,7 +115,7 @@
         <div style="height: 100px; margin: 10px;color:blue;">You can resize me by dragging any of the corners.</div>
     {/macro}
    
-    {macro resizeContentMacro()}
+    {macro resizemacro()}
         <div style="margin: 10px;color:green">${data["view:Dialog"].resizetext}</div>
     {/macro}
    

--- a/samples/widgets/touch/dialog/DialogTpl.tpl
+++ b/samples/widgets/touch/dialog/DialogTpl.tpl
@@ -18,7 +18,7 @@
   	},  	
   	animateIn: "slide right",
   	animateOut:"slide left",
-  	contentMacro: "myMacro",
+  	macro: "myMacro",
     absolutePosition : {
         top : 400,
         left : 400

--- a/snippets/custom-widgets/SimpleLabel.js
+++ b/snippets/custom-widgets/SimpleLabel.js
@@ -20,9 +20,9 @@ Aria.classDefinition({
             if (cfg.content) {
                 out.write(aria.utils.String.escapeHTML(this._cfg.content));
             }
-            if (cfg.contentMacro) {
+            if (cfg.macro) {
                 // it is possible to call a macro when generating the widget markup
-                out.callMacro(cfg.contentMacro);
+                out.callMacro(cfg.macro);
             }
         }
     }

--- a/snippets/widgets/dialog/Snippet.tpl
+++ b/snippets/widgets/dialog/Snippet.tpl
@@ -8,7 +8,7 @@
         ////#wgtDialogSimple
         {@aria:Dialog {
             title: "Dialog Sample",
-            contentMacro : "dialogMacro",
+            macro : "dialogMacro",
             icon: "std:info",
             width: 400,
             maxHeight: 500,
@@ -19,7 +19,7 @@
         ////#wgtDialogAction
         {@aria:Dialog {
             title: "Dialog Sample",
-            contentMacro : "dialogMacro",
+            macro : "dialogMacro",
             icon: "std:fire",
             width: 400,
             maxHeight: 500,
@@ -32,7 +32,7 @@
         {@aria:Dialog {
             id : "sampleDialogOne",
             title: "Dialog Sample",
-            contentMacro : "dialogMacro",
+            macro : "dialogMacro",
             movable : true
         }/}
         ////#wgtDialogMove1
@@ -41,7 +41,7 @@
         {@aria:Dialog {
             id : "sampleDialogTwo",
             title: "Dialog Sample",
-            contentMacro : "dialogMacro",
+            macro : "dialogMacro",
             movable : true,
             movableProxy : {
                 type : "Overlay"
@@ -53,7 +53,7 @@
         {@aria:Dialog {
             id : "sampleDialogThree",
             title: "Dialog Sample",
-            contentMacro : "dialogMacro",
+            macro : "dialogMacro",
             movable : true,
             movableProxy : {
                 type : "CloneOverlay",
@@ -68,7 +68,7 @@
         {@aria:Dialog {
             id : "sampleDialogFour",
             title: "Dialog Sample",
-            contentMacro : "dialogMacro",
+            macro : "dialogMacro",
             movable : true,
             ondragstart : {
                 fn : "onDragStart"
@@ -82,7 +82,7 @@
 		////#wgtDialogResize
 		{@aria:Dialog {
             id : "movableDialog",
-            contentMacro : {
+            macro : {
                 name : "displayDialogContent"
             },
             resizable : true,


### PR DESCRIPTION
`contentMacro` in Dialog config was deprecated as of AT 1.4.10.

The change in some of the places of this pull request is not necessary  (as they're just local names for data model entries etc.) but I wanted to keep consistency.
