### PR TITLE
Removing unused attributes sclass

### DIFF
--- a/samples/widgets/selectbox/bindoptions/BindOptions.tpl
+++ b/samples/widgets/selectbox/bindoptions/BindOptions.tpl
@@ -8,7 +8,6 @@
         label: "All Countries: ",
         labelWidth:220,
         options: data.OptionsBindingValues,
-        sclass: skin.skinType,
         bind: {
             options : {
                 to : "OptionsBindingValues",


### PR DESCRIPTION
Removing the usage of sclass parameter that was using an undefined variable skin.
Fix #29
