### PR TITLE
Typos in Italian resources and replacement of the refresh sample

### DIFF
--- a/samples/features/refresh/TemplateRefresh.tpl
+++ b/samples/features/refresh/TemplateRefresh.tpl
@@ -1,115 +1,85 @@
 {Template {
-	"$classpath" : 'samples.features.refresh.TemplateRefresh',
-	"$hasScript" : true
+	$classpath : "samples.features.refresh.TemplateRefresh",
+	$hasScript : true
 }}
 
 	{macro main()}
-		{call sectionBinding()/}
-		<hr/>
-		{var doInit = initCountIfNeeded() /}
-		<br/>
-		<b>Main macro:</b> Count=${data["view:count"]}<br/>
 
-		{section "Section1"}
-			<b>Section1:</b> Count=${data["view:count"]}
-		{/section}<br/>
+        /*
+         * First refresh example
+         */
 
-		{for var i=0;3>i;i++}
-			{section "SectionX_"+i}
-				<b>SectionX_${i}:</b> Count=${data["view:count"]}<br/>
-				{for var j=0;2>j;j++}
-					{section "SectionX_"+i+"_"+j}
-						<b>SectionX_${i}_${j}:</b> Count=${data["view:count"]}
-					{/section}<br/>
-				{/for}
-			{/section}
-		{/for}
-		{section "sectionMacroRefresh"}
-			{call macroRefresh()/}
-		{/section}<br/>
+        <h1>Manual refresh of a section</h1>
 
-		<br/>
-		{for var i=1;3>i;i++}
-			// 2 Fields bound to the same data !
-			{@aria:TextField {
-				label:'Count Value (display #'+i+'):',
-				tooltip:'Type any value to update the counter (note: you will need to explicitly call of a refresh to update non-bound data)',
-				bind:{
-					value:{to:"view:count", inside:data}
-				}
-			}/}
-			<br/>
-		{/for}
-		<br/>
+        {section {
+            id: "manualRefresh",
+            type: "div",
+            macro: "counterOne"
+        }/}
 
-		Refresh:
-		{@aria:Button {
-			label:'All',
-			onclick:'updateCountAndRefresh'
-		}/}
-		{@aria:Button {
-			label:'Section1',
-			onclick:{ fn: updateCountAndRefresh, args: {filterSection:"Section1"} }
-		}/}
-		{@aria:Button {
-			label:'SectionX_1',
-			onclick:{ fn: updateCountAndRefresh, args: {filterSection:"SectionX_1"} }
-		}/}
-		{@aria:Button {
-			label:'SectionX_1_1',
-			onclick:{ fn: updateCountAndRefresh, args: {filterSection:"SectionX_1_1"} }
-		}/}
-		{@aria:Button {
-			label:'macroRefresh',
-			onclick:{ fn: updateCountAndRefresh, args: {outputSection:"sectionMacroRefresh", macro: "macroRefresh"} }
-		}/}
+        {@aria:Button {
+            id: "manualButton",
+            margins: "10 x x x",
+            label: "Call manual refresh",
+            onclick: manualRefresh
+        }/}
 
+        /*
+         * Second refresh example
+         */
 
-	{/macro}
+        <h1>Refresh using widget binding</h1>
 
-	{macro macroRefresh()}
-		<b>macroRefresh:</b> Count=${data["view:count"]}
-	{/macro}
+        <div>
+            The value of counter 2 is:
+            {@aria:TextField {
+                width: 30,
+                bind: {
+                    value: {to:"counter2", inside:data}
+                }
+             }/}
+        </div>
 
-	{macro sectionBinding()}
-		<h2>Section Bindings</h2>
+        {@aria:Button {
+            id: "widgetButton",
+            margins: "10 x x x",
+            label: "Change counter2 value",
+            onclick: widgetRefresh
+        }/}
 
-		{section {
-			id: "SectionA",
-			bindRefreshTo : [{inside: data, to: "sectionRefresh"}]
-		}}
-			<p>
-				{@aria:NumberField {
-					label:"Bound Number field:",
-					labelPos:"left",
-					labelAlign:"right",
-					block:true,
-					value:'0',
-					disabled: true,
-					value:data['sectionRefresh'],
-					errorMessages:["Please type in a number"]
-				}/}
-				<br/>
-				{@aria:Button {
-					label:"Increment value in datamodel ++",
-					onclick: {
-							fn: "onclickrefresh",
-							args: "2"
-					}
-				}/}
-			</p>
-			<br/>
-				{section "SectionA1"}
-					<h2>Child Section</h2>
-					<p>Bound number field should show <b>${data.sectionRefresh}</b></p>
-				{/section}
-			{call sectionBinding2()/}
-		{/section}
-	{/macro}
-	{macro sectionBinding2()}
-		{section "SectionA2"}
-			<h2>Child Section within a sub macro</h2>
-			<p>The bound number field should show <b>${data.sectionRefresh}</b></p>
-		{/section}
-	{/macro}
+        /*
+         * Third refresh example
+         */
+
+        <h1>Automatic refresh using bindRefreshTo</h1>
+
+        {section {
+            id: "automaticRefresh",
+            type: "div",
+            bindRefreshTo: [
+                { to:"counter3", inside:data }
+            ],
+            macro: {
+		        name: "counterThree",
+                args: ["hey!"]
+            }
+        }/}
+
+        {@aria:Button {
+            id: "automaticButton",
+            margins: "10 x x x",
+            label: "Change counter3 value",
+            onclick: automaticRefresh
+        }/}
+
+    {/macro}
+
+    {macro counterOne()}
+        The value of counter 1 is: ${data.counter1}
+    {/macro}
+
+    {macro counterThree(msg)}
+        The value of counter 3 is: ${data.counter3} / ${msg}
+    {/macro}
+
 {/Template}

--- a/samples/features/refresh/TemplateRefreshScript.js
+++ b/samples/features/refresh/TemplateRefreshScript.js
@@ -3,50 +3,32 @@
  * @class samples.features.refresh.TemplateRefreshScript
  */
 Aria.tplScriptDefinition({
-	$classpath : 'samples.features.refresh.TemplateRefreshScript',
-	$prototype : {
+    $classpath : 'samples.features.refresh.TemplateRefreshScript',
+    $prototype : {
 
-		initCountIfNeeded : function () {
-			var data = this.data;
-			if (!data["view:count"]) {
-				// count doesn't exist - cf. tutorial on variables and meta-data
-				this.$json.setValue(data, "view:count", "1");
-			}
-			data = null;
-		},
+        $dataReady : function () {
+            this.data = {
+                counter1 : 2,
+                counter2 : 5,
+                counter3 : 9
+            };
 
-		/**
-		 * Update the count meta-data used to get different values each time a refresh is made
-		 */
-		updateCount : function () {
-			var data = this.data;
-			if (isNaN(data["view:count"])) {
-				this.$json.setValue(data, "view:count", data["view:count"] + 1);
-			} else {
-				this.$json.setValue(data, "view:count", String(parseInt(data["view:count"], 10) + 1));
-			}
-			data = null;
-		},
+        },
 
-		updateCountAndRefresh : function (evt, args) {
+        manualRefresh : function () {
+            this.data.counter1++;
+            this.$refresh({
+                section : "manualRefresh"
+            });
+        },
 
-			this.updateCount();
+        widgetRefresh : function () {
+            aria.utils.Json.setValue(this.data, "counter2", parseInt(this.data.counter2, 10) + 1);
+        },
 
-			this.$refresh(args);
-		},
+        automaticRefresh : function () {
+            this.$json.setValue(this.data, "counter3", this.data.counter3 + 1);
+        }
 
-		onclickrefresh : function () {
-			var data = this.data;
-			var showValue;
-
-			if (data.sectionRefresh === undefined) {
-				showValue = 1;
-			} else {
-				showValue = data["sectionRefresh"] + 1
-			}
-			this.$json.setValue(data, "sectionRefresh", showValue);
-
-		}
-
-	}
+    }
 });

--- a/samples/templates/i18n/res/SampleRes_it_IT.js
+++ b/samples/templates/i18n/res/SampleRes_it_IT.js
@@ -4,14 +4,14 @@ Aria.resourcesDefinition({
 		"buttons" : {
 			"label" : {
 				"ok" : "OK",
-				"avail" : "Disponibilita"
+				"avail" : "Disponibilit\u00E0"
 			}
 		},
 		"messages" : {
 			"label" : {
-				"welcome" : "Benvenuto a questo esempio localizzato.",
+				"welcome" : "Benvenuto in questo esempio localizzato.",
 				"clickOK" : "Hai cliccato OK.",
-				"clickAvail" : "Hai cliccato sul pulsante Disponibilita."
+				"clickAvail" : "Hai cliccato sul pulsante Disponibilit\u00E0."
 			}
 		}
 	}


### PR DESCRIPTION
There was a typo in the Italian resources for the localization sample.

The refresh example has been replaced because it contained deprecated section syntax.
