### PR TITLE
fix for page engine sample broken image paths

### DIFF
--- a/samples/pageEngine/addressBook/templates/ContactLibrary.tml
+++ b/samples/pageEngine/addressBook/templates/ContactLibrary.tml
@@ -35,28 +35,28 @@
         {if contact.facebook}
           <a class="social-link-fb facebook-icon" {on click {fn : module.navigate, scope : module, args : {type : "facebook", item : contact}, resIndex : -1}/}></a>
         {else/}
-          <img class="social-link-fb" src="./templates/imgs/facebook24bw.png">
+          <img class="social-link-fb" src="imgs/facebook24bw.png">
         {/if}
       </div>
       <div class="tw-box">
         {if contact.twitter}
           <a class="social-link-tw twitter-icon"></a>
         {else/}
-          <img class="social-link-tw" src="./templates/imgs/twitter24bw.png">
+          <img class="social-link-tw" src="imgs/twitter24bw.png">
         {/if}
       </div>
       <div class="lin-box">
         {if contact.linkedin}
           <a class="social-link-lin linkedin-icon"></a>
         {else/}
-          <img class="social-link-lin" src="./templates/imgs/linkedin24bw.png">
+          <img class="social-link-lin" src="imgs/linkedin24bw.png">
         {/if}
       </div>
       <div class="fli-box">
         {if contact.flickr}
           <a class="social-link-fli flickr-icon"></a>
         {else/}
-          <img class="social-link-fli" src="./templates/imgs/flickr24bw.png">
+          <img class="social-link-fli" src="imgs/flickr24bw.png">
         {/if}
       </div>
     </div>

--- a/samples/pageEngine/addressBook/templates/ContactsCSS.tpl.css
+++ b/samples/pageEngine/addressBook/templates/ContactsCSS.tpl.css
@@ -75,7 +75,7 @@
     }
 
     .social-link-fb:hover {
-      background-image: url(./templates/imgs/facebook24.png);
+      background-image: url(imgs/facebook24.png);
       width: 24px;
       height: 24px;
       display: inline-block;
@@ -95,7 +95,7 @@
     }    
 
     .facebook-icon {
-      background-image: url(./templates/imgs/facebook24.png);
+      background-image: url(imgs/facebook24.png);
       background-repeat: no-repeat;
       display: inline-block;
       cursor: pointer;

--- a/samples/pageEngine/addressBook/templates/ResultsBoxCSS.tpl.css
+++ b/samples/pageEngine/addressBook/templates/ResultsBoxCSS.tpl.css
@@ -36,7 +36,7 @@
   		border-radius: 10px;
   		cursor: pointer;
   		text-shadow: 0 -1px 1px rgba(0, 0, 0, 0.15);
-  		background-image: url(./templates/imgs/fade.png);
+  		background-image: url(imgs/fade.png);
   		background-repeat: repeat-x;
   		background-position: bottom left;
   		-webkit-transition: background-color .4s ease-in;
@@ -60,7 +60,7 @@
     }
     
     .facebook-icon {
-      background-image: url(./templates/imgs/facebook24.png);
+      background-image: url(imgs/facebook24.png);
       background-repeat: no-repeat;
       display: inline-block;
       cursor: pointer;
@@ -75,7 +75,7 @@
     }
     
     .twitter-icon {
-      background-image: url(./templates/imgs/twitter24.png);
+      background-image: url(imgs/twitter24.png);
       background-repeat: no-repeat;
       display: inline-block;
       cursor: pointer;
@@ -90,7 +90,7 @@
     }
     
     .linkedin-icon {
-      background-image: url(./templates/imgs/linkedin24.png);
+      background-image: url(imgs/linkedin24.png);
       background-repeat: no-repeat;
       display: inline-block;
       cursor: pointer;
@@ -105,7 +105,7 @@
     }
     
     .flickr-icon {
-      background-image: url(./templates/imgs/flickr24.png);
+      background-image: url(imgs/flickr24.png);
       background-repeat: no-repeat;
       display: inline-block;
       cursor: pointer;

--- a/samples/pageEngine/addressBook/templates/SearchBoxCSS.tpl.css
+++ b/samples/pageEngine/addressBook/templates/SearchBoxCSS.tpl.css
@@ -74,7 +74,7 @@
   		border-radius: 10px;
   		cursor: pointer;
   		text-shadow: 0 -1px 1px rgba(0, 0, 0, 0.15);
-  		background-image: url(./templates/imgs/fade.png);
+  		background-image: url(imgs/fade.png);
   		background-repeat: repeat-x;
   		background-position: bottom left;
   		-webkit-transition: background-color .4s ease-in;
@@ -90,7 +90,7 @@
     }
 
     .search-button.loader {
-      background-image: url(./templates/imgs/loader.gif);
+      background-image: url(imgs/loader.gif);
       background-repeat: no-repeat;
       background-position-x: 75px;
       background-position-y: 10px;


### PR DESCRIPTION
This resolves an issue with images not appearing for the Page Engine sample.  The issue was raised in the [aria templates repo](https://github.com/ariatemplates/ariatemplates/issues/828) and has been closed referring to this PR for the solution.
