### PR TITLE
Replacement of contentMacro with Macro for aria:Dialog configuration

### DIFF
--- a/samples/customization/application/Customization.tpl
+++ b/samples/customization/application/Customization.tpl
@@ -30,7 +30,7 @@
             onclick: toggleSampleAppDialog
         }/}
         {@aria:Dialog {
-            contentMacro: "customModuleDialog",
+            macro: "customModuleDialog",
             modal: true,
             title: "Add a custom module",
             bind: {
@@ -42,7 +42,7 @@
         }}
         {/@aria:Dialog}
         {@aria:Dialog {
-            contentMacro: "customTemplateDialog",
+            macro: "customTemplateDialog",
             modal: true,
             title: "Set a custom template",
             bind: {
@@ -54,7 +54,7 @@
         }}
         {/@aria:Dialog}
         {@aria:Dialog {
-            contentMacro: "sampleApp",
+            macro: "sampleApp",
             modal: true,
             title: "Sample application",
             bind: {

--- a/samples/customization/flow/FlowCustomization.tpl
+++ b/samples/customization/flow/FlowCustomization.tpl
@@ -24,7 +24,7 @@
         }/}
 
         {@aria:Dialog {
-            contentMacro: "sampleApp",
+            macro: "sampleApp",
             modal: true,
             title: "Sample application",
             bind: {
@@ -37,7 +37,7 @@
         {/@aria:Dialog}
 
         {@aria:Dialog {
-            contentMacro: "customFlowDialog",
+            macro: "customFlowDialog",
             modal: true,
             title: "Add a custom module",
             bind: {

--- a/samples/utils/xdr/CrossDomain.tpl
+++ b/samples/utils/xdr/CrossDomain.tpl
@@ -21,7 +21,7 @@
           icon: "std:info",
           modal: false,
           visible: false,
-          contentMacro: "defaultContent",
+          macro: "defaultContent",
           bind:{
               "visible": { inside: data, to: 'response'}
           }


### PR DESCRIPTION
contentMacro property has been removed in version 1.5.1 of Aria Templates.
