### PR TITLE
Removal of bindValue from touch:Slider widget configuration

### DIFF
--- a/samples/widgets/touch/slider/Slider.tpl
+++ b/samples/widgets/touch/slider/Slider.tpl
@@ -5,21 +5,23 @@
   }
 }}
 
-  
+
   {macro main()}
     Here is a Touch Slider Widget bound with a Text Widget to display a value between $0 and $100 :
 
     <br><br>
 
     {@touch:Slider {
-      bindValue: {
-        to: "slider",
-        inside: data
+      bind : {
+        value : {
+          to: "slider",
+          inside: data
+        }
       },
       width: 100
     }/}
     <br>
-	
+
 	{section {
       id : "display",
 	  macro : "values",
@@ -29,7 +31,7 @@
       }]
 
   }/}
-    
+
 
     <br><br>
 


### PR DESCRIPTION
`bindValue` property of touch:Slider was removed from the framework (https://github.com/ariatemplates/ariatemplates/commit/67a667eccd5797e12c7f3c34d72ff4ec195d68fa) in favour of bind.value.
