### PR TITLE
Fixed a little syntax error, not permitted in IE7.

### DIFF
--- a/samples/widgets/multiautocomplete/basic/MultiAutoComplete.tpl
+++ b/samples/widgets/multiautocomplete/basic/MultiAutoComplete.tpl
@@ -1,6 +1,6 @@
 {Template {
 	$classpath : "samples.widgets.multiautocomplete.basic.MultiAutoComplete",
-	$hasScript : true,
+	$hasScript : true
 }}
 
 	{macro main()}

--- a/samples/widgets/multiautocomplete/rangevalues/MultiAutoComplete.tpl
+++ b/samples/widgets/multiautocomplete/rangevalues/MultiAutoComplete.tpl
@@ -1,6 +1,6 @@
 {Template {
 	$classpath : "samples.widgets.multiautocomplete.rangevalues.MultiAutoComplete",
-	$hasScript : true,
+	$hasScript : true
 }}
 
 	{macro main()}


### PR DESCRIPTION
This prevented two samples for the multiautocomplete to be parsed properly by IE7's JavaScript engine.
