### PR TITLE
feat ariatemplates/ariatemplates#1427 Customization of widget's error messages

### DIFF
--- a/snippets/widgets/DefaultErrorMessages.tpl
+++ b/snippets/widgets/DefaultErrorMessages.tpl
@@ -1,0 +1,82 @@
+{Template {
+	$classpath : "snippets.widgets.DefaultErrorMessages",
+	$hasScript : true
+}}
+
+{macro main()}
+	{call static()/}
+	{call bound()/}
+{/macro}
+
+{macro static()}
+	{@aria:NumberField {
+		defaultErrorMessages : {
+			"validation" : "Local default error message for NumberField's validation."
+		}
+	}/}
+
+	{@aria:TimeField {
+		defaultErrorMessages : {
+			"validation" : "Local default error message for TimeField's validation."
+		}
+	}/}
+
+////#static
+	{@aria:DateField {
+		defaultErrorMessages : {
+			"validation" : "Local default error message for DateField's validation.",
+			"minValue" : "Local default error message for DateField's minimum date validation.",
+			"maxValue" : "Local default error message for DateField's maximum date validation."
+		}
+	}/}
+////#static
+
+	{@aria:AutoComplete {
+		resourcesHandler : this.data.resourcesHandler,
+		defaultErrorMessages : {
+			"validation" : "Local default error message for AutoComplete's validation."
+		}
+	}/}
+{/macro}
+
+{macro bound()}
+	{@aria:NumberField {
+		bind : {
+			defaultErrorMessages : {
+				inside : this.data.defaultErrorMessages,
+				to : "NumberField"
+			}
+		}
+	}/}
+
+	{@aria:TimeField {
+		bind : {
+			defaultErrorMessages : {
+				inside : this.data.defaultErrorMessages,
+				to : "TimeField"
+			}
+		}
+	}/}
+
+////#bound
+	{@aria:DateField {
+		bind : {
+			defaultErrorMessages : {
+				inside : this.data.defaultErrorMessages,
+				to : "DateField"
+			}
+		}
+	}/}
+////#bound
+
+	{@aria:AutoComplete {
+		bind : {
+			defaultErrorMessages : {
+				inside : this.data.defaultErrorMessages,
+				to : "AutoComplete"
+			}
+		}
+	}/}
+{/macro}
+
+{/Template}

--- a/snippets/widgets/DefaultErrorMessagesScript.js
+++ b/snippets/widgets/DefaultErrorMessagesScript.js
@@ -1,0 +1,48 @@
+Aria.tplScriptDefinition({
+	$classpath : "snippets.widgets.DefaultErrorMessagesScript",
+	$dependencies : ["aria.core.AppEnvironment", "aria.resources.handlers.LCResourcesHandler"],
+	$prototype : {
+		$dataReady : function () {
+			var resourcesHandler = new aria.resources.handlers.LCResourcesHandler();
+			resourcesHandler.setSuggestions([]);
+			this.data.resourcesHandler = resourcesHandler;
+
+			////#datamodel
+			this.data.defaultErrorMessages = {};
+			this.data.defaultErrorMessages["DateField"] = {
+				"validation" : "Bound local default error message for DateField's validation.",
+				"minValue" : "Bound local default error message for DateField's minimum date validation.",
+				"maxValue" : "Bound local default error message for DateField's maximum date validation."
+			};
+			////#datamodel
+
+			this.data.defaultErrorMessages["NumberField"] = {
+				"validation" : "Bound local default error message for NumberField's validation."
+			};
+
+			this.data.defaultErrorMessages["TimeField"] = {
+				"validation" : "Bound local default error message for TimeField's validation."
+			};
+
+			this.data.defaultErrorMessages["AutoComplete"] = {
+				"validation" : "Bound local default error message for AutoComplete's validation."
+			};
+		},
+
+		setGlobalMessages : function() {
+			////#global
+			aria.core.AppEnvironment.setEnvironment({
+				"widgetSettings" : {
+					"defaultErrorMessages" : {
+						"DateField" : {
+							"validation" : "Global default error message for DateField's validation.",
+							"minValue" : "Global default error message for DateField's minimum date validation.",
+							"maxValue" : "Global default error message for DateField's maximum date validation."
+						}
+					}
+				}
+			}, null, true);
+			////#global
+		}
+	}
+});


### PR DESCRIPTION
Documentation for feature described there: ariatemplates/ariatemplates#1427

Not all parts of the snippet have been prepared to be used, but it provides a common place to demonstrate all the aspects of the feature, mixing global and specific ones.

Below is the original description of the feature.

----

It is now possible for a user to customize the error messages used by the widgets.

There are 3 levels of error messages specifications, the two firsts being user configuration while the last is the hardcoded default.

This is resolved in this order of precedence:

- local: widget's configuration
- global: application's environment
- hardcoded: widget's resources