### PR TITLE
fix: Wai autocomplete widget to use codeMatch=false and preselect="none"

### DIFF
--- a/samples/widgets/autocomplete/wai/WaiAutoComplete.tpl
+++ b/samples/widgets/autocomplete/wai/WaiAutoComplete.tpl
@@ -10,6 +10,7 @@
             label : "Country",
             labelWidth: 100,
             autoFill : false,
+            preselect : "none",
             resourcesHandler : this.nationsHandler,
             waiSuggestionsStatusGetter: this.waiSuggestionsStatusGetter,
             waiSuggestionAriaLabelGetter: this.waiSuggestionAriaLabelGetter
@@ -20,6 +21,7 @@
             label : "City",
             labelWidth: 100,
             autoFill : false,
+            preselect : "none",
             resourcesHandler : this.citiesHandler,
             waiSuggestionsStatusGetter: this.waiSuggestionsStatusGetter,
             waiSuggestionAriaLabelGetter: this.waiSuggestionAriaLabelGetter

--- a/samples/widgets/autocomplete/wai/WaiAutoCompleteScript.js
+++ b/samples/widgets/autocomplete/wai/WaiAutoCompleteScript.js
@@ -3,7 +3,9 @@ Aria.tplScriptDefinition({
     $dependencies : ["samples.common.autocomplete.AutoCompleteResourceHandler"],
     $constructor : function () {
         this.nationsHandler = samples.common.autocomplete.AutoCompleteResourceHandler.getNationsHandler(1);
+        this.nationsHandler.codeMatch = false;
         this.citiesHandler = samples.common.autocomplete.AutoCompleteResourceHandler.getCitiesHandler(1);
+        this.citiesHandler.codeMatch = false;
     },
     $destructor : function () {
         this.nationsHandler.$dispose();


### PR DESCRIPTION
Note that this PR relies on ariatemplates/ariatemplates#1610