### PR TITLE
feat: Adds aria-label related properties to the DatePicker sample

### DIFF
--- a/samples/widgets/datepicker/wai/WaiDatePicker.tpl
+++ b/samples/widgets/datepicker/wai/WaiDatePicker.tpl
@@ -4,6 +4,9 @@
 
     {macro main()}
 
+        <span id="departure-date-label" class="xSROnly">Date of departure</span>
+        <span id="datepicker-explanation" class="xSROnly">Date format is Day/Month/Year, press down arrow to access the Calendar widget</span>
+
         {@aria:DatePicker {
             label: "Departure date",
             labelWidth: 100,
@@ -11,7 +14,10 @@
             waiAria: true,
             waiAriaCalendarLabel: "Calendar table. Use arrow keys to navigate and space to validate.",
             waiAriaDateFormat: "EEEE d MMMM yyyy",
-            calendarShowShortcuts: false
+            calendarShowShortcuts: false,
+            waiDescribedBy: "datepicker-explanation",
+            waiLabelledBy: "departure-date-label",
+            waiLabelHidden: true
         }/}<br><br>
 
         {@aria:DatePicker {
@@ -21,7 +27,10 @@
             waiAria: true,
             waiAriaCalendarLabel: "Calendar table. Use arrow keys to navigate and space to validate.",
             waiAriaDateFormat: "MMMM d",
-            calendarShowShortcuts: false
+            calendarShowShortcuts: false,
+            waiDescribedBy: "datepicker-explanation",
+            waiLabel: "Date of return",
+            waiLabelHidden: true
         }/}
 
     {/macro}


### PR DESCRIPTION
**Adds 4 new properties for the DatePicker sample:**

- `waiLabel:` sets 'aria-label' on the input, value will be used as the attributes value
- `waiDescribedBy:` sets 'aria-describedby' on the input, value will be used as the attributes value
- `waiLabelledBy:` sets 'aria-labelledby' on the input, value will be used as the attributes value
- `waiLabelHidden:` sets 'aria-hidden' on the label, value will be used as the attributes value
