### PR TITLE
feat: Adds waiSuggestionsStatusGetter to the SelectBox sample allowing JAWS to announce the number of suggestions in the list

### DIFF
--- a/samples/widgets/selectbox/SampleUsage.tpl
+++ b/samples/widgets/selectbox/SampleUsage.tpl
@@ -13,6 +13,13 @@
 					to : "country",
 					inside : data.widgets
 				}
+			},
+			waiSuggestionsStatusGetter : function (number) {
+			 if (number === 0) {
+			   return "There is no suggestion.";
+			 } else {
+			   return (number == 1 ? "There is one suggestion" : "There are " + number + " suggestions") + ", use up and down arrow keys to navigate and enter to validate.";
+			 }
 			}
 		}/}
 


### PR DESCRIPTION
**Adds a new property for the SelectBox sample:**

- `waiSuggestionsStatusGetter:` The callback specified in this parameter is called when the number of suggestions changes. It receives the new number of suggestions and should return the message to be read by screen readers. This parameter is only used if waiAria is true.